### PR TITLE
fix module not found check, proxy switched from status code 410 to 404

### DIFF
--- a/internal/modproxy/modproxy.go
+++ b/internal/modproxy/modproxy.go
@@ -100,7 +100,7 @@ func Query(modpath string, cached bool) (*Module, bool, error) {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(res.Body)
-		if res.StatusCode == http.StatusGone && bytes.HasPrefix(body, []byte("not found:")) {
+		if res.StatusCode == http.StatusNotFound && bytes.HasPrefix(body, []byte("not found:")) {
 			return nil, false, nil
 		}
 		msg := string(body)


### PR DESCRIPTION
It looks like proxy.golang.org switched from returning 410 to 404 in the case of not finding the version.