### PR TITLE
Update Go version to 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.25
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/icholy/gomajor
 
-go 1.21
+go 1.25
 
 require (
 	golang.org/x/mod v0.19.0


### PR DESCRIPTION
## Summary
- Updates Go version from 1.21 to 1.25 in go.mod
- Updates GitHub workflow to use Go 1.25
- Matches the currently installed toolchain version

## Test plan
- [x] Verified no vet issues with `go vet ./...`
- [x] Ran staticcheck with no issues found
- [x] Ran govulncheck with no vulnerabilities found
- [x] Updated govulncheck to work with Go 1.25

🤖 Generated with [Claude Code](https://claude.ai/code)